### PR TITLE
Version bump to 331 with jdk11.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-slim
+FROM openjdk:11-jdk-slim
 
 ARG MIRROR="https://repo1.maven.org/maven2/io/prestosql"
 ARG PRESTO_VERSION="331"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:8-jre-slim
 
-ARG MIRROR="https://repo1.maven.org/maven2/com/facebook/presto"
-ARG PRESTO_VERSION="0.216"
+ARG MIRROR="https://repo1.maven.org/maven2/io/prestosql"
+ARG PRESTO_VERSION="331"
 ARG PRESTO_BIN="${MIRROR}/presto-server/${PRESTO_VERSION}/presto-server-${PRESTO_VERSION}.tar.gz"
 ARG PRESTO_CLI_BIN="${MIRROR}/presto-cli/${PRESTO_VERSION}/presto-cli-${PRESTO_VERSION}-executable.jar"
 
@@ -36,11 +36,8 @@ RUN mkdir -p $PRESTO_HOME && \
     chmod +x presto && \
     chown -R ${PRESTO_USER}:${PRESTO_USER} $PRESTO_HOME
 
-# Need to work with python2
-# See: https://github.com/prestodb/presto/issues/4678
-ENV PYTHON2_DEBIAN_VERSION 2.7.13-2
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		python="${PYTHON2_DEBIAN_VERSION}" \
+		python \
 	&& rm -rf /var/lib/apt/lists/* \
     && cd /usr/local/bin \
 	&& rm -rf idle pydoc python python-config 


### PR DESCRIPTION
Changes part of this pull request:
1. The version of JDK changed to 11 as recommended by the 331 version of presto.
2. JRE to JDK moves to avoid ERROR of resource not found.
3. Mirror URL and version naming convention change as per the new Prestosql repository than Facebook presto one.
4. PYTHON2_DEBIAN_VERSION pin no more required.

This merge request is after testing this docker setup with helm presto stable chart on Kubernetes version 1.14. Few configuration changes are required on helm config maps for this to work. 
LMK if any further edits are required. I will send a PR for a presto stable helm chart as well to keep both the projects in sync.